### PR TITLE
Update linting and pre-commit rules 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,12 @@
     "prettier"
   ],
   "rules": {
-    "@next/next/no-img-element": "off"
+    "@next/next/no-img-element": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "destructuredArrayIgnorePattern": "^__"
+      }
+    ]
   }
 }


### PR DESCRIPTION
To streamline our development workflow and reduce inefficiencies, this PR introduces two changes to our existing workflow

1. Building the project was removed from the pre-commit workflow

This change is mainly due to the amount of time it takes to build the project. The original build step was to check both eslint and typescript typing errors. However, since we've now updated the lint command in package.json to include these two steps (in a much more efficient manner), I believe the benefit of saving time outweighs the minor possibility of a Next.JS misconfiguration. In addition, due to how we've setup our CI/CD workflow, a broken build will always prevent a merge from happening, and thus thus change should practically cause no harm. Thus, I've removed the build step from husky's pre-commit check.

2. Update eslint config to allow unused vars which match the ^__ prefix

Since many hooks rely on destructuring by array, it is beneficial to have a prefix to identify a variable as intentionally unused when developing. Thus, I've introduced an unused-var bypass for variables which match the /^__/u regex check to make development easier.