### PR TITLE
Resolve race condition in user setup

### DIFF
--- a/src/app/(default_site)/onboarding/page.tsx
+++ b/src/app/(default_site)/onboarding/page.tsx
@@ -63,7 +63,10 @@ export default function OnboardingPage() {
             if (decodedToken?.role !== "ROLE_NOT_SETUP")
                 subscribeWebPush({ auth_token: data.accessToken });
 
-            router.push("/");
+            // TODO: Fix race condition
+            setTimeout(() => {
+                router.push("/");
+            }, 1000);
         },
         onError(error: KnownErrorResponse | Error) {
             if (


### PR DESCRIPTION
This PR temporarily resolves the race condition on user onboarding by delaying the redirection on user setup success by 1000ms, thereby giving `login` time to set cookies. This is a temporary fix and a better solution should be discussed.