### PR TITLE
Prevent editor from preserve style when paste on contents

### DIFF
--- a/src/components/ReferenceMarker/ReferenceMarkerProvider.tsx
+++ b/src/components/ReferenceMarker/ReferenceMarkerProvider.tsx
@@ -94,7 +94,8 @@ export default function ReferenceMarkerProvider({
         return () => observer.disconnect();
     }, [inputRef]);
 
-    // Setup paste event listener on the input area
+    // Setup paste event listener on the input area.
+    // Prevent the ecitor from preserving text styles when pasting text from other styles.
     useEffect(() => {
         const handlePaste = (event: ClipboardEvent) => {
             event.preventDefault(); // Stop default paste behavior

--- a/src/components/ReferenceMarker/ReferenceMarkerProvider.tsx
+++ b/src/components/ReferenceMarker/ReferenceMarkerProvider.tsx
@@ -94,6 +94,43 @@ export default function ReferenceMarkerProvider({
         return () => observer.disconnect();
     }, [inputRef]);
 
+    // Setup paste event listener on the input area
+    useEffect(() => {
+        const handlePaste = (event: ClipboardEvent) => {
+            event.preventDefault(); // Stop default paste behavior
+
+            if (!event.clipboardData) return;
+            const text = event.clipboardData.getData("text/plain");
+
+            // Insert text at cursor position
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount === 0) return;
+
+            const range = selection.getRangeAt(0);
+            range.deleteContents(); // Remove selected text if any
+
+            const textNode = document.createTextNode(text);
+            range.insertNode(textNode);
+
+            // Move cursor after inserted text
+            range.setStartAfter(textNode);
+            range.setEndAfter(textNode);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        };
+
+        const editor = inputRef.current;
+        if (editor) {
+            editor.addEventListener("paste", handlePaste);
+        }
+
+        return () => {
+            if (editor) {
+                editor.removeEventListener("paste", handlePaste);
+            }
+        };
+    }, []);
+
     // Handle selection change and areas
     // Check whether the selection overlaps with an existing reference marker
     const rangeOverlaps = (


### PR DESCRIPTION
Transfer the content that is pasted on the editor from click board to plain text before paste on.