### PR TITLE
Fix bug: throwing error when notification permisstion denine

### DIFF
--- a/src/components/Conversation/Shared/AuthorProfile.tsx
+++ b/src/components/Conversation/Shared/AuthorProfile.tsx
@@ -1,3 +1,5 @@
+"use client";
+import { useEffect, useState } from "react";
 import { Avatar } from "@mantine/core";
 
 type AuthorProfileProps = {
@@ -11,23 +13,28 @@ export default function AuthorProfile({
     authorAvatar,
     createdAt,
 }: AuthorProfileProps) {
-    const formatTimeAgo = (date: Date) => {
+    const [displayedTimeString, setDisplayedTimeString] = useState<string>("");
+
+    useEffect(() => {
+        if (!createdAt) return;
+
         const now = new Date(); // Get current local time
         const diffInSeconds = Math.floor(
-            (now.getTime() - date.getTime()) / 1000,
+            (now.getTime() - createdAt.getTime()) / 1000,
         );
         const diffInMinutes = Math.floor(diffInSeconds / 60);
         const diffInHours = Math.floor(diffInMinutes / 60);
         const diffInDays = Math.floor(diffInHours / 24);
 
-        if (diffInSeconds < 60) return "剛剛";
-        if (diffInMinutes < 60) return `${diffInMinutes} 分鐘前`;
-        if (diffInHours < 24) return `${diffInHours} 小時前`;
-        if (diffInDays < 7) return `${diffInDays} 天前`;
-
+        if (diffInSeconds < 60) setDisplayedTimeString("剛剛");
+        else if (diffInMinutes < 60)
+            setDisplayedTimeString(`${diffInMinutes} 分鐘前`);
+        else if (diffInHours < 24)
+            setDisplayedTimeString(`${diffInHours} 小時前`);
+        else if (diffInDays < 7) setDisplayedTimeString(`${diffInDays} 天前`);
         // Show absolute date if older than a week
-        return date.toLocaleDateString();
-    };
+        else setDisplayedTimeString(createdAt.toLocaleDateString());
+    }, []);
 
     return (
         <div className="mb-1 flex">
@@ -40,11 +47,10 @@ export default function AuthorProfile({
             <p className="ml-1.5 inline-block text-xs font-normal text-neutral-600">
                 {authorName}
             </p>
-            {createdAt && (
-                <p className="ml-3 inline-block text-xs font-normal text-neutral-600">
-                    {formatTimeAgo(createdAt)}
-                </p>
-            )}
+
+            <p className="ml-3 inline-block text-xs font-normal text-neutral-600">
+                {displayedTimeString}
+            </p>
         </div>
     );
 }

--- a/src/components/Conversation/Shared/AuthorProfile.tsx
+++ b/src/components/Conversation/Shared/AuthorProfile.tsx
@@ -34,7 +34,7 @@ export default function AuthorProfile({
         else if (diffInDays < 7) setDisplayedTimeString(`${diffInDays} 天前`);
         // Show absolute date if older than a week
         else setDisplayedTimeString(createdAt.toLocaleDateString());
-    }, []);
+    }, [createdAt]);
 
     return (
         <div className="mb-1 flex">

--- a/src/lib/requests/settings/postSubscribe.ts
+++ b/src/lib/requests/settings/postSubscribe.ts
@@ -1,5 +1,6 @@
 import type { WebPushSubscription } from "@/types/users.types";
 import { parseJsonWhileHandlingErrors } from "../transformers";
+import { boolean } from "zod";
 
 type postSubscribeParams = {
     subscription: WebPushSubscription;
@@ -69,11 +70,12 @@ export const generateSubscriptionObject =
         return subscriptionObject;
     };
 
-async function requestNotificationPermission() {
+async function requestNotificationPermission(): Promise<boolean> {
     const permission = await Notification.requestPermission();
     if (permission !== "granted") {
-        throw new Error("Notification permission denied");
+        return false;
     }
+    return true;
 }
 
 export type subscribeWebPushParams = {
@@ -99,7 +101,11 @@ export const subscribeWebPush = async ({
     }
 
     // Request Notification and Push Permission
-    requestNotificationPermission();
+    const hasPermission = await requestNotificationPermission();
+    if (!hasPermission) {
+        console.info("Send notification permission denied");
+        return;
+    }
 
     // Get the push subscription object
     const subscriptionObject = await generateSubscriptionObject();

--- a/src/lib/requests/settings/postSubscribe.ts
+++ b/src/lib/requests/settings/postSubscribe.ts
@@ -1,6 +1,5 @@
 import type { WebPushSubscription } from "@/types/users.types";
 import { parseJsonWhileHandlingErrors } from "../transformers";
-import { boolean } from "zod";
 
 type postSubscribeParams = {
     subscription: WebPushSubscription;


### PR DESCRIPTION
# Type of change
- Bug fix

# Purpose
- The original implementation of registering a service worker will throw an error when the user chooses not to grant permission to the notification. This fix removes that feature since it shouldn't be an error.