### PR TITLE
Fix bug: throwing error when notification permisstion denine

### DIFF
--- a/src/lib/requests/settings/postSubscribe.ts
+++ b/src/lib/requests/settings/postSubscribe.ts
@@ -69,11 +69,12 @@ export const generateSubscriptionObject =
         return subscriptionObject;
     };
 
-async function requestNotificationPermission() {
+async function requestNotificationPermission(): Promise<boolean> {
     const permission = await Notification.requestPermission();
     if (permission !== "granted") {
-        throw new Error("Notification permission denied");
+        return false;
     }
+    return true;
 }
 
 export type subscribeWebPushParams = {
@@ -99,7 +100,11 @@ export const subscribeWebPush = async ({
     }
 
     // Request Notification and Push Permission
-    requestNotificationPermission();
+    const hasPermission = await requestNotificationPermission();
+    if (!hasPermission) {
+        console.info("Send notification permission denied");
+        return;
+    }
 
     // Get the push subscription object
     const subscriptionObject = await generateSubscriptionObject();


### PR DESCRIPTION
# Type of change
- Bug fix

# Purpose
- The original implementation of registering a service worker will throw an error when the user chooses not to grant permission to the notification. This fix removes that feature since it shouldn't be an error.