### PR TITLE
Fix construct URL exception when invalid URL

### DIFF
--- a/src/components/Conversation/Facts/ReferenceBar.tsx
+++ b/src/components/Conversation/Facts/ReferenceBar.tsx
@@ -17,6 +17,10 @@ export default function ReferenceBar({
 }: FactBarProps) {
     const pageURL = safeConstructURL(reference.url);
 
+    if (!pageURL) {
+        return null;
+    }
+
     return (
         <Link
             key={reference.id}

--- a/src/components/Conversation/Facts/ReferenceBar.tsx
+++ b/src/components/Conversation/Facts/ReferenceBar.tsx
@@ -2,7 +2,7 @@ import type { FactReference } from "@/types/conversations.types";
 import { GlobeAltIcon } from "@heroicons/react/16/solid";
 import { Loader } from "@mantine/core";
 import Link from "next/link";
-import { safeDecodeURI } from "@/lib/utils/safeDecodeURI";
+import { safeConstructURL } from "@/lib/utils/safeConstructURL";
 
 type FactBarProps = {
     reference: FactReference;
@@ -15,7 +15,7 @@ export default function ReferenceBar({
     showSrcTitle,
     isLoading,
 }: FactBarProps) {
-    const pageURL = new URL(safeDecodeURI(reference.url) ?? "example.com");
+    const pageURL = safeConstructURL(reference.url);
 
     return (
         <Link

--- a/src/components/Conversation/Facts/ReferenceBar.tsx
+++ b/src/components/Conversation/Facts/ReferenceBar.tsx
@@ -17,10 +17,6 @@ export default function ReferenceBar({
 }: FactBarProps) {
     const pageURL = safeConstructURL(reference.url);
 
-    if (!pageURL) {
-        return null;
-    }
-
     return (
         <Link
             key={reference.id}
@@ -42,7 +38,7 @@ export default function ReferenceBar({
             )}
 
             <span className="font-sans text-sm font-normal text-neutral-500">
-                {pageURL.hostname.replace("www.", "")}
+                {pageURL ? pageURL.hostname.replace("www.", "") : reference.url}
             </span>
             {showSrcTitle && (
                 <span className="truncate text-sm text-gray-600">

--- a/src/components/Conversation/Facts/ViewpointFactReference.tsx
+++ b/src/components/Conversation/Facts/ViewpointFactReference.tsx
@@ -11,13 +11,10 @@ export default function ViewpointFactReference({
     reference,
 }: ViewpointFactReferenceProps) {
     const pageURL = safeConstructURL(reference.url);
-    if (!pageURL) {
-        return null;
-    }
 
     return (
         <Link
-            href={pageURL.href}
+            href={reference.url}
             passHref
             target="_blank"
             rel="noopener noreferrer"
@@ -41,7 +38,7 @@ export default function ViewpointFactReference({
             )}
 
             <h1 className="inline-block pl-1 font-sans text-xs font-normal text-neutral-500">
-                {pageURL.hostname.replace("www.", "")}
+                {pageURL ? pageURL.hostname.replace("www.", "") : reference.url}
             </h1>
         </Link>
     );

--- a/src/components/Conversation/Facts/ViewpointFactReference.tsx
+++ b/src/components/Conversation/Facts/ViewpointFactReference.tsx
@@ -1,7 +1,7 @@
 import type { FactReference } from "@/types/conversations.types";
 import { GlobeAltIcon } from "@heroicons/react/16/solid";
 import Link from "next/link";
-import { safeDecodeURI } from "@/lib/utils/safeDecodeURI";
+import { safeConstructURL } from "@/lib/utils/safeConstructURL";
 
 type ViewpointFactReferenceProps = {
     reference: FactReference;
@@ -10,7 +10,7 @@ type ViewpointFactReferenceProps = {
 export default function ViewpointFactReference({
     reference,
 }: ViewpointFactReferenceProps) {
-    const pageURL = new URL(safeDecodeURI(reference.url) ?? "example.com");
+    const pageURL = new URL(safeConstructURL(reference.url) ?? "example.com");
 
     return (
         <Link

--- a/src/components/Conversation/Facts/ViewpointFactReference.tsx
+++ b/src/components/Conversation/Facts/ViewpointFactReference.tsx
@@ -10,7 +10,10 @@ type ViewpointFactReferenceProps = {
 export default function ViewpointFactReference({
     reference,
 }: ViewpointFactReferenceProps) {
-    const pageURL = new URL(safeConstructURL(reference.url) ?? "example.com");
+    const pageURL = safeConstructURL(reference.url);
+    if (!pageURL) {
+        return null;
+    }
 
     return (
         <Link

--- a/src/lib/utils/safeConstructURL.ts
+++ b/src/lib/utils/safeConstructURL.ts
@@ -1,5 +1,5 @@
-export function safeConstructURL(url: string): URL {
-    let pageURL: URL;
+export function safeConstructURL(url: string): URL | null {
+    let pageURL: URL | null;
     try {
         pageURL = new URL(decodeURI(url));
     } catch (e) {
@@ -8,7 +8,7 @@ export function safeConstructURL(url: string): URL {
         } else {
             console.error("Unexpected error:", e);
         }
-        pageURL = new URL("https://example.com");
+        pageURL = null;
     }
     return pageURL;
 }

--- a/src/lib/utils/safeConstructURL.ts
+++ b/src/lib/utils/safeConstructURL.ts
@@ -1,12 +1,14 @@
-export function safeDecodeURI(uri: string): string | null {
+export function safeConstructURL(url: string): URL {
+    let pageURL: URL;
     try {
-        return decodeURI(uri);
+        pageURL = new URL(decodeURI(url));
     } catch (e) {
         if (e instanceof URIError) {
             console.error("Invalid URI:", e.message);
         } else {
             console.error("Unexpected error:", e);
         }
-        return null; // Return null to indicate failure
+        pageURL = new URL("https://example.com");
     }
+    return pageURL;
 }


### PR DESCRIPTION
# Type of change
- Fix

# Purpose
- Add a safe construct URL utility to handle exceptions when trying to construct a URL object from an invalid URL.