### PR TITLE
Set URL favicon alt property to empty string

### DIFF
--- a/src/components/Conversation/Facts/ReferenceBar.tsx
+++ b/src/components/Conversation/Facts/ReferenceBar.tsx
@@ -31,7 +31,7 @@ export default function ReferenceBar({
                 <img
                     className="h-4 w-4 rounded-full"
                     src={reference.icon}
-                    alt="favicon"
+                    alt=""
                 />
             ) : (
                 <GlobeAltIcon className="h-4 w-4 text-gray-600" />

--- a/src/components/Conversation/Facts/ViewpointFactReference.tsx
+++ b/src/components/Conversation/Facts/ViewpointFactReference.tsx
@@ -31,7 +31,7 @@ export default function ViewpointFactReference({
                 <img
                     className="inline-block h-3 w-3 rounded-full"
                     src={reference.icon}
-                    alt="favicon"
+                    alt=""
                 />
             ) : (
                 <GlobeAltIcon className="inline-block h-3 w-3 rounded-full" />


### PR DESCRIPTION
# Type of change
- Fix

# Purpose
- Set the `alt` of the URL favicon in the reference bar and viewpoint fact reference to an empty string to prevent showing the text 'favicon' and overflow when fail to display the real favicon